### PR TITLE
[WIP] Update node adapter to 0.2 spec as described by avro file

### DIFF
--- a/beacon-adapters/beacon-nodejs/README.md
+++ b/beacon-adapters/beacon-nodejs/README.md
@@ -9,7 +9,9 @@
 * [Technologies](#technologies)
 
 ##What it is
-This project contains BDK (beacon development kit) for Node.js developers. It provides a skeleton of a simple beacon allowing the developers to plug in their own data/functionality. The API makes sure the response produced is compatible with what the Beacon of Beacons can consume.
+This project contains BDK (beacon development kit) for Node.js developers.
+It provides a skeleton of a simple beacon allowing the developers to plug in their own data/functionality.
+The API makes sure the response produced is compatible with what the Beacon of Beacons can consume.
 
 ##System requirements
 All you need to build this project restify, which you can install via npm:


### PR DESCRIPTION
I based my changes on the 0.2 avro spec here: https://github.com/ga4gh/schemas/commit/a88e0395e998cf5c8b72a276a474cf8751e55464

It sounds like this was the right choice based on comments in https://github.com/mcupak/beacon-of-beacons/issues/52, but the query string in the rest of the codebase still seems to be using 'allele' as a parameter. Let me know if I should go off of the spec draft document instead! 